### PR TITLE
Replacing vanilla Prometheus release with GMP Collector release

### DIFF
--- a/prombench/manifests/cluster-infra/3b_prometheus-meta.yaml
+++ b/prombench/manifests/cluster-infra/3b_prometheus-meta.yaml
@@ -201,7 +201,7 @@ spec:
       securityContext:
         runAsUser: 0
       containers:
-      - image: quay.io/prometheus/prometheus:v2.42.0
+      - image: gke.gcr.io/prometheus-engine/prometheus:v2.35.0-gmp.6-gke.0
         args:
         - "--config.file=/etc/prometheus/config/prometheus.yaml"
         - "--storage.tsdb.path=/data"

--- a/prombench/manifests/prombench/benchmark/3b_prometheus-test_deployment.yaml
+++ b/prombench/manifests/prombench/benchmark/3b_prometheus-test_deployment.yaml
@@ -149,7 +149,7 @@ spec:
         runAsUser: 0
       containers:
       - name: prometheus
-        image: quay.io/prometheus/prometheus:{{ .RELEASE }}
+        image: gke.gcr.io/prometheus-engine/prometheus:v2.35.0-gmp.6-gke.0
         imagePullPolicy: Always
         command: [ "/bin/prometheus" ]
         args: [


### PR DESCRIPTION
This PR replaces the vanilla Prometheus image with the GMP Collector image to have it write data to Monarch via GCM. 