### PR TITLE
Fixing nginx service type to support GCP env

### DIFF
--- a/prombench/manifests/cluster-infra/2_ingress-nginx-controller.yaml
+++ b/prombench/manifests/cluster-infra/2_ingress-nginx-controller.yaml
@@ -206,8 +206,7 @@ metadata:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
 spec:
-  externalTrafficPolicy: Local
-  type: "{{ .NGINX_SERVICE_TYPE }}"
+  type: "NodePort"
   selector:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx


### PR DESCRIPTION
Pantheon does not allow services to be exposed externally via a LoadBalancer. Hence, nginx service is stuck in a pending state forever because it's type is LoadBalancer (by default/design) which makes deploying the nginx and other components impossible.