### PR TITLE
Increasing the scrape interval

### DIFF
--- a/prombench/manifests/cluster-infra/3b_prometheus-meta.yaml
+++ b/prombench/manifests/cluster-infra/3b_prometheus-meta.yaml
@@ -37,7 +37,7 @@ metadata:
 data:
   prometheus.yaml: |
     global:
-      scrape_interval: 20s
+      scrape_interval: 30s
 
     rule_files:
     - /etc/prometheus/alerts/*.yml

--- a/prombench/manifests/cluster-infra/3b_prometheus-meta.yaml
+++ b/prombench/manifests/cluster-infra/3b_prometheus-meta.yaml
@@ -37,7 +37,7 @@ metadata:
 data:
   prometheus.yaml: |
     global:
-      scrape_interval: 5s
+      scrape_interval: 20s
 
     rule_files:
     - /etc/prometheus/alerts/*.yml

--- a/prombench/manifests/prombench/benchmark/3a_prometheus-test_configmap.yaml
+++ b/prombench/manifests/prombench/benchmark/3a_prometheus-test_configmap.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   prometheus.yml: |
     global:
-      scrape_interval: 20s
+      scrape_interval: 30s
 
     scrape_configs:
     - job_name: kubelets

--- a/prombench/manifests/prombench/benchmark/3a_prometheus-test_configmap.yaml
+++ b/prombench/manifests/prombench/benchmark/3a_prometheus-test_configmap.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   prometheus.yml: |
     global:
-      scrape_interval: 5s
+      scrape_interval: 20s
 
     scrape_configs:
     - job_name: kubelets


### PR DESCRIPTION
This commit increases the scrape interval from 5s to 20s as a measure to constrain the amount of data written to GCM to avoid quota-related as well as container resources related errors/warnings.