### PR TITLE
Adding GitHub Actions to build and publish the prombench image to GHCR

### DIFF
--- a/.github/workflows/publish_container_image.yaml
+++ b/.github/workflows/publish_container_image.yaml
@@ -1,0 +1,46 @@
+name: "Publishing the container image"
+on:
+  push:
+    branches:
+    - master
+  workflow_dispatch: {}
+  
+env:
+  GITHUB_ORG: ${{ github.repository_owner }} # GoogleCloudPlatform
+  GITHUB_REPO: ${{ github.event.repository.name }} # prometheus-test-infra
+  IMAGE_REGISTRY: ghcr.io
+
+jobs:
+  build-and-push-docker-image:
+    name: Build the image and push to GitHub Container Registry
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Go build
+        run: |
+          cd infra
+          go build .
+          cd ..
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.IMAGE_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish the container image
+        run: |
+          IMAGE_NAME_AND_TAG=$(echo "${IMAGE_REGISTRY}/${GITHUB_ORG}/${GITHUB_REPO}/prombench:latest" | tr '[:upper:]' '[:lower:]')
+          docker build prombench/ --tag ${IMAGE_NAME_AND_TAG}
+          docker push ${IMAGE_NAME_AND_TAG}


### PR DESCRIPTION
Once a commit lands to the master (default) branch, this GH Action would get triggered to build the prombench image and publish it to GHCR.