### PR TITLE
Use JSON logger for the Prometheus images

### DIFF
--- a/prombench/manifests/cluster-infra/3b_prometheus-meta.yaml
+++ b/prombench/manifests/cluster-infra/3b_prometheus-meta.yaml
@@ -208,6 +208,8 @@ spec:
         - "--storage.tsdb.retention.size=500GB"  # 50% of the total storage available.
         - "--web.enable-lifecycle"
         - "--web.external-url=http://{{ .DOMAIN_NAME }}/prometheus-meta"
+        # JSON log format is needed for GKE to display log levels correctly.
+        - "--log.format=json"
         name: prometheus
         volumeMounts:
         - name: config-volume

--- a/prombench/manifests/prombench/benchmark/3b_prometheus-test_deployment.yaml
+++ b/prombench/manifests/prombench/benchmark/3b_prometheus-test_deployment.yaml
@@ -69,6 +69,8 @@ spec:
           "--web.console.libraries=/usr/bin/console_libraries",
           "--web.console.templates=/usr/bin/consoles",
           "--config.file=/etc/prometheus/prometheus.yml",
+          # JSON log format is needed for GKE to display log levels correctly.
+          "--log.format=json"
           "--log.level=debug"
         ]
         volumeMounts:
@@ -158,6 +160,8 @@ spec:
           "--web.console.libraries=/etc/prometheus/console_libraries",
           "--web.console.templates=/etc/prometheus/consoles",
           "--config.file=/etc/prometheus/prometheus.yml",
+        # JSON log format is needed for GKE to display log levels correctly.
+          "--log.format=json"
           "--log.level=debug"
         ]
         volumeMounts:


### PR DESCRIPTION
GKE is showing all logs as errors. This is by design in https://cloud.google.com/stackdriver/docs/solutions/gke/managing-logs#best_practices.

Using the JSON logger fixes this issues and allows log level to appear correctly.

Added JSON log format to Prometheus-PR, Prometheus-Release and Prometheus-Meta.