### PR TITLE
Adding GKE-related labels to prometheus pods

### DIFF
--- a/prombench/manifests/cluster-infra/3b_prometheus-meta.yaml
+++ b/prombench/manifests/cluster-infra/3b_prometheus-meta.yaml
@@ -196,6 +196,11 @@ spec:
       labels:
         app: prometheus-meta
         prometheus: meta
+        app.kubernetes.io/prometheus: meta
+        app.kubernetes.io/component: meta
+        app.kubernetes.io/part-of: gmp
+        app.kubernetes.io/name: meta
+        app.kubernetes.io/version: meta
     spec:
       serviceAccountName: prometheus
       securityContext:

--- a/prombench/manifests/prombench/benchmark/3b_prometheus-test_deployment.yaml
+++ b/prombench/manifests/prombench/benchmark/3b_prometheus-test_deployment.yaml
@@ -18,6 +18,11 @@ spec:
       labels:
         app: prometheus
         prometheus: test-pr-{{ .PR_NUMBER }}
+        app.kubernetes.io/prometheus: test-pr-{{ .PR_NUMBER }}
+        app.kubernetes.io/component: test-pr-{{ .PR_NUMBER }}
+        app.kubernetes.io/part-of: gmp
+        app.kubernetes.io/name: test-pr-{{ .PR_NUMBER }}
+        app.kubernetes.io/version: test-pr-{{ .PR_NUMBER }}
     spec:
       serviceAccountName: prometheus
       affinity:
@@ -133,6 +138,11 @@ spec:
       labels:
         app: prometheus
         prometheus: test-{{ normalise .RELEASE }}
+        app.kubernetes.io/prometheus: test-{{ normalise .RELEASE }}
+        app.kubernetes.io/component: test-{{ normalise .RELEASE }}
+        app.kubernetes.io/part-of: gmp
+        app.kubernetes.io/name: test-{{ normalise .RELEASE }}
+        app.kubernetes.io/version: test-{{ normalise .RELEASE }}
     spec:
       serviceAccountName: prometheus
       affinity:


### PR DESCRIPTION
This adds the "app.kubernetes.io" labels to all the prometheus pods so that they are discoverable to GKE/GCM.