### PR TITLE
Adding "release-.+" regex to meta Prometheus's configfile

### DIFF
--- a/prombench/manifests/cluster-infra/3b_prometheus-meta.yaml
+++ b/prombench/manifests/cluster-infra/3b_prometheus-meta.yaml
@@ -164,7 +164,7 @@ data:
         replacement: /${1}/prometheus-pr/metrics
       - action: replace
         source_labels: [__meta_kubernetes_namespace,__meta_kubernetes_service_label_prometheus]
-        regex: prombench-(\d+);test-(?:master|main|v.+)
+        regex: prombench-(\d+);test-(?:master|main|v.+|release-.+)
         target_label: __metrics_path__
         replacement: /${1}/prometheus-release/metrics
       - action: replace


### PR DESCRIPTION
Since the release Prometheus pod is labelled as test-release-X-Y-Z-gmp, the meta monitoring Prometheus cannot detect the release Prometheus because of the missing "release.+" regex in the configfile. This causes prombench to collect incomplete metrics which results in bad data/results.